### PR TITLE
154 allow option to create a azureclient from environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv*
 req*
 yaml*
 .coverage
+run_client.py

--- a/cfa_azure/clients.py
+++ b/cfa_azure/clients.py
@@ -18,6 +18,7 @@ class AzureClient:
             config_path (str): path to configuration file, required if not using environment variables
             use_env_vars (bool): set to True to load configuration from environment variables
         """
+
         self.debug = None
         self.scaling = None
         self.input_container_name = None
@@ -38,8 +39,14 @@ class AzureClient:
         self.save_logs_to_blob = None
         
         logger.debug("Attributes initialized in client.")
-
-        if use_env_vars:
+        
+        if not config_path and not use_env_vars:
+            raise Exception(
+                "No configuration method specified. Please provide a config path or set `use_env_vars=True` to load settings from environment variables."
+                )
+        
+        # extract credentials using environment variables
+        elif use_env_vars:
             try:
                 missing_vars = helpers.check_env_req()
                 if missing_vars:

--- a/cfa_azure/helpers.py
+++ b/cfa_azure/helpers.py
@@ -1846,6 +1846,7 @@ def get_pool_full_info(
     return result
 
 
+
 def check_env_req() -> bool:
     """Checks if all necessary environment variables exist for the AzureClient.
     Returns true if all required variables are found, false otherwise.
@@ -1853,7 +1854,6 @@ def check_env_req() -> bool:
     Returns:
         bool: true if environment variables contain all required components, false otherwise
     """
-    
     config_to_env_var_map = {
         "Authentication.subscription_id": "AZURE_SUBSCRIPTION_ID",
         "Authentication.resource_group": "AZURE_RESOURCE_GROUP",
@@ -1871,15 +1871,13 @@ def check_env_req() -> bool:
         "Storage.storage_account_name": "AZURE_STORAGE_ACCOUNT_NAME",
         "Storage.storage_account_url": "AZURE_STORAGE_ACCOUNT_URL"
     }
-
     missing_vars = [env_var for env_var in config_to_env_var_map.values() if not os.getenv(env_var)]
     
     if not missing_vars:
         logger.debug("All required environment variables are set.")
-        return True
     else:
         logger.warning(f"Missing environment variables: {missing_vars}")
-        return False
+    return missing_vars
 
     
 def check_config_req(config: str):

--- a/cfa_azure/helpers.py
+++ b/cfa_azure/helpers.py
@@ -1846,6 +1846,42 @@ def get_pool_full_info(
     return result
 
 
+def check_env_req() -> bool:
+    """Checks if all necessary environment variables exist for the AzureClient.
+    Returns true if all required variables are found, false otherwise.
+
+    Returns:
+        bool: true if environment variables contain all required components, false otherwise
+    """
+    
+    config_to_env_var_map = {
+        "Authentication.subscription_id": "AZURE_SUBSCRIPTION_ID",
+        "Authentication.resource_group": "AZURE_RESOURCE_GROUP",
+        "Authentication.user_assigned_identity": "AZURE_USER_ASSIGNED_IDENTITY",
+        "Authentication.tenant_id": "AZURE_TENANT_ID",
+        "Authentication.batch_application_id": "AZURE_BATCH_APPLICATION_ID",
+        "Authentication.batch_object_id": "AZURE_BATCH_OBJECT_ID",
+        "Authentication.sp_application_id": "AZURE_SP_APPLICATION_ID",
+        "Authentication.vault_url": "AZURE_VAULT_URL",
+        "Authentication.vault_sp_secret_id": "AZURE_VAULT_SP_SECRET_ID",
+        "Authentication.subnet_id": "AZURE_SUBNET_ID",
+        "Batch.batch_account_name": "AZURE_BATCH_ACCOUNT_NAME",
+        "Batch.batch_service_url": "AZURE_BATCH_SERVICE_URL",
+        "Batch.pool_vm_size": "AZURE_POOL_VM_SIZE",
+        "Storage.storage_account_name": "AZURE_STORAGE_ACCOUNT_NAME",
+        "Storage.storage_account_url": "AZURE_STORAGE_ACCOUNT_URL"
+    }
+
+    missing_vars = [env_var for env_var in config_to_env_var_map.values() if not os.getenv(env_var)]
+    
+    if not missing_vars:
+        logger.debug("All required environment variables are set.")
+        return True
+    else:
+        logger.warning(f"Missing environment variables: {missing_vars}")
+        return False
+
+    
 def check_config_req(config: str):
     """checks if the config file has all the necessary components for the client
     Returns true if all components exist in config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cfa_azure"
-version = "1.0.9"
+version = "1.0.10"
 description = "module for use with Azure and Azure Batch"
 authors = ["Ryan Raasch <xng3@cdc.gov>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cfa_azure",
-    version="1.0.9",
+    version="1.0.10",
     description="module for use with Azure and Azure Batch",
     packages=find_packages(exclude=["tests", "venv"]),
     author="Ryan Raasch",


### PR DESCRIPTION
The clients.py and helpers.py file have been updated so that:

- users can now initiate azure client with either a config file or environment variables
- if the user opts to use environment variables to initiate azure, the output returns the missing variable(s) if any